### PR TITLE
Fix switching of cell names for empty cells in merge

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -73,7 +73,7 @@ MergeSparseDataAll <- function(datalist, library.names = NULL) {
     } else {
       full_mat <- rbind(full_mat, curr_s)
     }
-    col_offset <- max(full_mat[, 2])
+    col_offset <- length(allCells)
   }
   M <- sparseMatrix(
     i = full_mat[, 1],


### PR DESCRIPTION
This bug would only affect the merging of datasets which did not have a min UMI cutoff, and where cell-name needed to be consistent across multiple clustering analyses. 