### PR TITLE
Remove misplaced text in liger-package.Rd and prevent install warnings

### DIFF
--- a/man/liger-package.Rd
+++ b/man/liger-package.Rd
@@ -23,8 +23,6 @@ Maintainer: \packageMaintainer{liger}
 \references{
 ~~ Literature or other references for background information ~~
 }
-~~ Optionally other standard keywords, one per line, from file KEYWORDS in the R ~~
-~~ documentation directory ~~
 \keyword{ package }
 \seealso{
 ~~ Optional links to other man pages, e.g. ~~


### PR DESCRIPTION
This addresses issue #63. 