### PR TITLE
Added a check to ensure that resolution is defined

### DIFF
--- a/R/liger.R
+++ b/R/liger.R
@@ -1615,6 +1615,9 @@ quantileAlignSNF.list <- function(
     set.seed(seed = NULL)
     id.number <- sample(x = 1000000:9999999, size = 1)
   }
+  is.defined <- function(sym) class(try(sym, TRUE))!='try-error'
+  if(!is.defined(resolution)){stop("'resolution' is not properly defined")}
+  if(!is.finite(resolution)){stop("'resolution' is not properly defined")}
   idents <- snf$idents
   Hs <- object
   idents.rest <- SLMCluster(


### PR DESCRIPTION
Just had an error occur and this should stop it happening again.

I had called: 
a.pbmc <- quantileAlignSNF(a.pbmc, resolution = res, small.clust.thresh = 20)

However, I had forgotten to set 'res'. Because res does not get used until late in the function, it was 20 minutes or so until the function crashed. The lines I've added just check to ensure that res has been properly defined.