### PR TITLE
Fix cell order bug in subsetLiger

### DIFF
--- a/R/liger.R
+++ b/R/liger.R
@@ -4776,10 +4776,6 @@ subsetLiger <- function(object, clusters.use = NULL, cells.use = NULL, remove.mi
   nms <- names(object@raw.data)[!missing]
   names(raw.data) <- nms
   a <- createLiger(raw.data, remove.missing = remove.missing)
-  # Add back additional cell.data
-  if (ncol(a@cell.data) < ncol(object@cell.data)) {
-    a@cell.data <- droplevels(data.frame(object@cell.data[cells.use, ]))
-  }
   a@norm.data <- lapply(1:length(a@raw.data), function(i) {
     object@norm.data[[nms[i]]][, colnames(a@raw.data[[i]])]
   })
@@ -4793,6 +4789,11 @@ subsetLiger <- function(object, clusters.use = NULL, cells.use = NULL, remove.mi
   a@clusters <- droplevels(a@clusters)
   a@tsne.coords <- object@tsne.coords[names(a@clusters), ]
   a@H.norm <- object@H.norm[names(a@clusters), ]
+  # Add back additional cell.data
+  if (ncol(a@cell.data) < ncol(object@cell.data)) {
+    a@cell.data <- droplevels(data.frame(object@cell.data[names(a@clusters), ]))
+  }
+  
   a@W <- object@W
   a@V <- object@V
   a@var.genes <- object@var.genes

--- a/tests/testthat/test_post_factorization.R
+++ b/tests/testthat/test_post_factorization.R
@@ -244,19 +244,24 @@ test_that("Returns correct subsetted object", {
   expect_equal(rownames(ligex_subset@cell.data), rownames(ligex_subset@tsne.coords))
 })
 
-set.seed(1)
-ligex_subset <- subsetLiger(ligex, cells.use = sample(row.names(ligex@cell.data), 200))
+# create "pseudorandom" set of cells to downsample
+cells.use = c('CACTGAGACAGTCA', 'CD8_124', 'Bcell_103', 'Bcell_17', 'Bcell_236', 'GGGCCAACCTTGGA', 
+              'ACCTCCGATATGCG', 'Bcell_242', 'CD4_407', 'CD8_265', 'GACAGTACGAGCTT', 'GACCCTACTAAAGG', 
+              'DC_37', 'CD4_35', 'ATACTCTGGTATGC', 'CAAAGCTGAAAGTG', 'AGCACTGATGCTTT', 'Bcell_280', 
+              'CD4_503', 'DC_97', 'NK_192', 'GGCACGTGGCTTAG', 'CGTTTAACTGGTCA', 'TATGCGGATAACCG', 
+              'TGTGATCTGACACT', 'CD4_500', 'GGCGGACTTGAACC', 'ATGTAAACACCTCC', 'CD4_539', 'DC_12')
+ligex_subset <- subsetLiger(ligex, cells.use = cells.use)
 
 test_that("Returns correct subsetted object", {
   expect_equal(names(ligex_subset@raw.data), c('tenx', 'seqwell'))
-  expect_equal(dim(ligex_subset@raw.data[[1]]), c(10265, 101))
-  expect_equal(colnames(ligex_subset@raw.data[[1]])[1:3], c("AATGCGTGGCTATG", 
-                                                            "GAAAGATGATTTCC", "TTCCAAACTCCCAC"))
-  expect_equal(dim(ligex_subset@raw.data[[2]]), c(6697, 99))
-  expect_equal(colnames(ligex_subset@raw.data[[2]])[1:3], c("CD4_450", "Bcell_233",
-                                                            "Bcell_222"))
-  expect_equal(levels(ligex_subset@clusters), c("0", "1", "2", "3", "4", "5", "6", "7", "8"))
-  expect_equal(nrow(ligex_subset@cell.data), 200)
+  expect_equal(dim(ligex_subset@raw.data[[1]]), c(5233, 14))
+  expect_equal(colnames(ligex_subset@raw.data[[1]])[1:3], c("CACTGAGACAGTCA", 
+                                                            "GGGCCAACCTTGGA", "ACCTCCGATATGCG"))
+  expect_equal(dim(ligex_subset@raw.data[[2]]), c(4670, 16))
+  expect_equal(colnames(ligex_subset@raw.data[[2]])[1:3], c("CD8_124", "Bcell_103",
+                                                            "Bcell_17"))
+  expect_equal(levels(ligex_subset@clusters), c("0", "1", "2", "3", "4", "5", "6", "7"))
+  expect_equal(nrow(ligex_subset@cell.data), 30)
   expect_equal(rownames(ligex_subset@cell.data), rownames(ligex_subset@tsne.coords))
 })
 

--- a/tests/testthat/test_post_factorization.R
+++ b/tests/testthat/test_post_factorization.R
@@ -244,6 +244,22 @@ test_that("Returns correct subsetted object", {
   expect_equal(rownames(ligex_subset@cell.data), rownames(ligex_subset@tsne.coords))
 })
 
+set.seed(1)
+ligex_subset <- subsetLiger(ligex, cells.use = sample(row.names(ligex@cell.data), 200))
+
+test_that("Returns correct subsetted object", {
+  expect_equal(names(ligex_subset@raw.data), c('tenx', 'seqwell'))
+  expect_equal(dim(ligex_subset@raw.data[[1]]), c(10265, 101))
+  expect_equal(colnames(ligex_subset@raw.data[[1]])[1:3], c("AATGCGTGGCTATG", 
+                                                            "GAAAGATGATTTCC", "TTCCAAACTCCCAC"))
+  expect_equal(dim(ligex_subset@raw.data[[2]]), c(6697, 99))
+  expect_equal(colnames(ligex_subset@raw.data[[2]])[1:3], c("CD4_450", "Bcell_233",
+                                                            "Bcell_222"))
+  expect_equal(levels(ligex_subset@clusters), c("0", "1", "2", "3", "4", "5", "6", "7", "8"))
+  expect_equal(nrow(ligex_subset@cell.data), 200)
+  expect_equal(rownames(ligex_subset@cell.data), rownames(ligex_subset@tsne.coords))
+})
+
 # TODO: Add tests for ligerToSeurat and seuratToLiger functions 
 # after including functionality related to new cell.data slot 
 


### PR DESCRIPTION
This bug previously caused discrepancies in cell order between cell.data and other slots. 