### PR TITLE
Update quantile_norm to allow performing on list objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache: packages
 
 os:
   - linux
-  - osx
+  # - osx
 # add back osx later with clean solution for openmp/rcpparmadillo
 
 r: release

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: liger
 Type: Package
 Title: Linked Inference of Genomic Experimental Relationships
-Version: 0.5.0.9000
+Version: 0.5.0
 Date: 2018-04-09
 Author: Joshua Welch
 Maintainer: Joshua Welch <jwelch@broadinstitute.org>,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,6 @@ Suggests:
     GenomicRanges,
     S4Vectors,
     IRanges,
-    RANN.L1,
     org.Hs.eg.db,
     reactome.db,
     fgsea,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,8 @@
 
 S3method(optimizeALS,liger)
 S3method(optimizeALS,list)
+S3method(quantile_norm,liger)
+S3method(quantile_norm,list)
 export(Matrix.column_norm)
 export(calcARI)
 export(calcAgreement)

--- a/R/liger.R
+++ b/R/liger.R
@@ -2095,6 +2095,7 @@ linkGenesAndPeaks <- function(gene_counts, peak_counts, genes.list = NULL, dist 
 
   ### make Granges object for genes
   gene.names <- read.csv2(path_to_coords, sep = "\t", header = FALSE, stringsAsFactors = F)
+  gene.names <- gene.names[complete.cases(gene.names), ]
   genes.coords <- GenomicRanges::GRanges(
     seqnames = gene.names$V1,
     ranges = IRanges::IRanges(as.numeric(gene.names$V2), end = as.numeric(gene.names$V3))
@@ -2110,7 +2111,7 @@ linkGenesAndPeaks <- function(gene_counts, peak_counts, genes.list = NULL, dist 
     genes.list <- colnames(gene_counts)
   }
   missing_genes <- !genes.list %in% names(genes.coords)
-  if (missing_genes!=0){
+  if (sum(missing_genes)!=0){
     print(
       paste0(
         "Removing ", sum(missing_genes),
@@ -2118,7 +2119,7 @@ linkGenesAndPeaks <- function(gene_counts, peak_counts, genes.list = NULL, dist 
       )
     )
   }
-  genes.list <- genes.list[!missing_genes]
+  genes.list <- genes.list[!missing_genes] 
   genes.coords <- genes.coords[genes.list]
 
   print("Calculating correlation for gene-peak pairs...")

--- a/R/liger.R
+++ b/R/liger.R
@@ -1606,6 +1606,7 @@ suggestK <- function(object, k.test = seq(5, 50, 5), lambda = 5, thresh = 1e-4, 
 #' @param max_sample Maximum number of cells used for quantile normalization of each cluster 
 #' and factor. (default 1000)
 #' @param refine.knn whether to increase robustness of cluster assignments using KNN graph.(default TRUE)
+#' @param rand.seed Random seed to allow reproducible results (default 1)
 #' @param ... Arguments passed to other methods
 #'
 #' @return \code{liger} object with 'H.norm' and 'clusters' slot set.
@@ -1646,8 +1647,10 @@ quantile_norm.list <- function(
     max_sample = 1000,
     eps = 0.9,
     refine.knn = T,
+    rand.seed = 1,
     ...
 ) {
+  set.seed(rand.seed)
   if (!all(sapply(X = object, FUN = is.matrix))) {
     stop("All values in 'object' must be a matrix")
   }

--- a/man/quantile_norm.Rd
+++ b/man/quantile_norm.Rd
@@ -2,9 +2,13 @@
 % Please edit documentation in R/liger.R
 \name{quantile_norm}
 \alias{quantile_norm}
+\alias{quantile_norm.list}
+\alias{quantile_norm.liger}
 \title{Quantile align (normalize) factor loadings}
 \usage{
-quantile_norm(
+quantile_norm(object, ...)
+
+\method{quantile_norm}{list}(
   object,
   quantiles = 50,
   ref_dataset = NULL,
@@ -14,11 +18,28 @@ quantile_norm(
   do.center = F,
   max_sample = 1000,
   eps = 0.9,
-  refine.knn = T
+  refine.knn = T,
+  ...
+)
+
+\method{quantile_norm}{liger}(
+  object,
+  quantiles = 50,
+  ref_dataset = NULL,
+  min_cells = 20,
+  knn_k = 20,
+  dims.use = NULL,
+  do.center = F,
+  max_sample = 1000,
+  eps = 0.9,
+  refine.knn = T,
+  ...
 )
 }
 \arguments{
 \item{object}{\code{liger} object. Should run optimizeALS before calling.}
+
+\item{...}{Arguments passed to other methods}
 
 \item{quantiles}{Number of quantiles to use for quantile normalization (default 50).}
 

--- a/man/quantile_norm.Rd
+++ b/man/quantile_norm.Rd
@@ -19,6 +19,7 @@ quantile_norm(object, ...)
   max_sample = 1000,
   eps = 0.9,
   refine.knn = T,
+  rand.seed = 1,
   ...
 )
 
@@ -63,6 +64,8 @@ and factor. (default 1000)}
 accurate nearest neighbor graphs but take much longer to computer.}
 
 \item{refine.knn}{whether to increase robustness of cluster assignments using KNN graph.(default TRUE)}
+
+\item{rand.seed}{Random seed to allow reproducible results (default 1)}
 }
 \value{
 \code{liger} object with 'H.norm' and 'clusters' slot set.


### PR DESCRIPTION
`quantile_norm` now supports both `list` object and `liger` object. Also added random seed setting in it to allow robust reproducible results. 